### PR TITLE
added migration section to pull request template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -20,6 +20,9 @@ Describe in a few sentences the approach you took to address the problem.
 Example:
 > The CSV import logic generalizes well so I simply added the previously unsupported transaction types to the list of transactions. The outright import failures were caused by transactions with empty dates, so I added some code to ignore those. Finally, for any transaction we ignored I added logging in place so that in the future we have a good idea what transactions fail to import, without having to download and analyze the user's CSVs.
 
+## Migration
+If you are running a DB migration make sure you have read the [How to run a database migration doc](https://www.notion.so/cointracker/How-to-run-a-database-migration-af5f44646abc46d1a5275be75b63c49a). Include any migration steps that will help reviewing your migration PR.
+
 ## Future work
 While addressing the problem you might have noticed other problems which are orthogonal. If that's the case, summarise the issues here and consider creating corresponding tickets in Linear.
 


### PR DESCRIPTION
## Problem description
DB migrations have too often been the cause of outages in CoinTracker. We need to make sure that we run migrations by the playbook.

## Solution
Add a migrations section to the PR description with a link to the migrations playbook.

## Future work
We are in parallel improving the tooling to ensure DB migrations are run in a safe way. See https://github.com/coin-tracker/coin-tracker-server/pull/11236

## Required for SOC2 compliance

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
- [ ] Automated tests covering modified code pass
