### PR TITLE
Comment out comments + examples

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,11 +1,17 @@
 ## Problem description
+
+<!---
 Describe here what problem you are solving. If you are adding new functionality, describe why the new functionality is added. Often this is (or should be) the same description is in the Linear ticket.
 Please don't just link to the Linear ticket here, don't force the reviewer to jump back and forth between GH and Linear.
 
+
 Example:
 > Support for SomeExchange is quite broken. Either the imports fail outright (ca. 25% of the cases) or when an unsupported transaction is encountered it is silently ignored, i.e. there is no indication to the user that certain transactions were not imported.
+--->
 
 ## Background
+
+<!---
 You've just put a lot of effort into understanding the underlying code before making a change. Share these leanings with
 the reviewer. Assume they don’t know the code very well.
 
@@ -13,21 +19,31 @@ Example:
 > The CSV import logic for BlockFi is pretty straight-forward:
 >- transfers with a positive amount are credits, with a negative amount debits
 >- trades are transactions of type ["Trade", "Ach Trade"] that share the same datetime
+--->
 
 ## Solution
+
+<!---
 Describe in a few sentences the approach you took to address the problem.
 
 Example:
 > The CSV import logic generalizes well so I simply added the previously unsupported transaction types to the list of transactions. The outright import failures were caused by transactions with empty dates, so I added some code to ignore those. Finally, for any transaction we ignored I added logging in place so that in the future we have a good idea what transactions fail to import, without having to download and analyze the user's CSVs.
+--->
 
 ## Migration
+
+<!---
 If you are running a DB migration make sure you have read the [How to run a database migration doc](https://www.notion.so/cointracker/How-to-run-a-database-migration-af5f44646abc46d1a5275be75b63c49a). Include any migration steps that will help reviewing your migration PR.
+--->
 
 ## Future work
+
+<!---
 While addressing the problem you might have noticed other problems which are orthogonal. If that's the case, summarise the issues here and consider creating corresponding tickets in Linear.
 
 Example:
 > At the UX level there is no indication for transactions that are ignored. This is something we should address. I created ticket XXX.
+--->
 
 ## Required for SOC2 compliance
 


### PR DESCRIPTION
## Problem description
I've realized developers currently have to manually delete all the helpful comments + examples in our PR template for each PR they open. While it's good to have a good structured template with instructions on what a good PR looks like it would be nice if we could leave those helpers as comments.

Example:
> Support for SomeExchange is quite broken. Either the imports fail outright (ca. 25% of the cases) or when an unsupported transaction is encountered it is silently ignored, i.e. there is no indication to the user that certain transactions were not imported.

^ Example of the problem

## Solution
By commenting out these comments + examples in the template they will continue to show during the writing of a PR description but will not be displayed after the developer creates the PR. 😄 

Example:
> The CSV import logic generalizes well so I simply added the previously unsupported transaction types to the list of transactions. The outright import failures were caused by transactions with empty dates, so I added some code to ignore those. Finally, for any transaction we ignored I added logging in place so that in the future we have a good idea what transactions fail to import, without having to download and analyze the user's CSVs.

^ This would not show up after I open the PR

## Required for SOC2 compliance

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
- [ ] Automated tests covering modified code pass
